### PR TITLE
Improved robustness and added parallel scrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin
 include
 lib
 .Python
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ ccj
 *.pyc
 *.orig
 *sublime*
+bin
+include
+lib
+.Python

--- a/countyapi/management/commands/discharge_inmates.py
+++ b/countyapi/management/commands/discharge_inmates.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+import logging
+
+from django.core.management.base import BaseCommand
+
+from countyapi.management.commands.utils import fetch_page
+from countyapi.models import CountyInmate
+
+
+log = logging.getLogger('main')
+
+
+class Command(BaseCommand):
+    """
+    This scans over the database of inmates and dtermines which of them of been discharged.
+    It does this by finding all of the inmates whose last_seen_date is prior to today and
+    who have not been discharged and checks if they stil have a details page. If they do
+    then their last_seen_date is updated to today. If they do not have a details page then
+    they are marked as discharged.
+    """
+    help = "Scan known inmates and discharge any not found on Cook County Sheriff's website."
+    option_list = BaseCommand.option_list + ()
+
+    __COOK_COUNTY_INMATE_DETAILS_URL = \
+        'http://www2.cookcountysheriff.org/search2/details.asp?jailnumber='
+    __NUMBER_OF_ATTEMPTS = 5
+
+    # does not take use the args and options parameters
+    def handle(self, *args, **options):
+        log.debug("%s - Scaning for inmates to discharge." % str(datetime.now()))
+
+        discharged = 0
+        today = self.beginning_of_today()
+        inmates = CountyInmate.objects.filter(discharge_date_earliest__exact=None, last_seen_date__lt=today)
+        log.debug("Number inmates to check is %d." % len(inmates))
+        now = datetime.now()
+        for inmate in inmates:
+            inmate_page = fetch_page(self.__COOK_COUNTY_INMATE_DETAILS_URL + inmate.jail_id, self.__NUMBER_OF_ATTEMPTS)
+            if inmate_page is None:
+                inmate.discharge_date_earliest = inmate.last_seen_date
+                inmate.discharge_date_latest = now
+                discharged += 1
+                log.debug("Discharged %s - Earliest: %s, Latest: %s" % (inmate.jail_id,
+                                                                        inmate.discharge_date_earliest,
+                                                                        now))
+            inmate.save()
+        log.debug("%s - Discharged %d." % (str(datetime.now()), discharged))
+
+    def beginning_of_today(self):
+        date_format = '%Y-%m-%d'
+        return datetime.strptime(datetime.today().strftime(date_format), date_format)

--- a/countyapi/management/commands/scrape_inmates.py
+++ b/countyapi/management/commands/scrape_inmates.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         return document('#mainContent table tr td:last-child a')
 
     def handle(self, *args, **options):
-        log.debug("Scraping inmates from Cook County Sheriff's site.")
+        log.debug("%s - Scraping inmates from Cook County Sheriff's site." % str(datetime.now()))
 
         self.options = options
 
@@ -91,7 +91,7 @@ class Command(BaseCommand):
             discharged = self.calculate_discharge_date(seen)
             log.debug("%s inmates discharged." % len(discharged))
 
-        log.debug("Imported %s inmate records)" % (records))
+        log.debug("%s - Imported %s inmate records)" % (str(datetime.now()), records))
 
     def calculate_discharge_date(self, seen):
         """
@@ -103,7 +103,7 @@ class Command(BaseCommand):
         for inmate in not_present_or_discharged:
             inmate.discharge_date_earliest = inmate.last_seen_date
             inmate.discharge_date_latest = now
-            log.debug("Discharged %s - Earliest: %s earliest, Latest: %s" % (inmate.jail_id, inmate.last_seen_date, now))
+            log.debug("Discharged %s - Earliest: %s, Latest: %s" % (inmate.jail_id, inmate.discharge_date_earliest, now))
             inmate.save()
         return not_present_or_discharged
 

--- a/countyapi/models.py
+++ b/countyapi/models.py
@@ -81,9 +81,10 @@ class ChargesHistory(models.Model):
     charges_citation = models.TextField(null=True)
     date_seen = models.DateField(null=True)
 
+
 class InmateSummaries(models.Model):
     """
-    Model that displays count of inmates in system by date 
+    Model that displays count of inmates in system by date
     """
     date = models.DateField(null=False)
     current_inmate_count = models.IntegerField(null=False, blank=False)

--- a/cron.sh
+++ b/cron.sh
@@ -3,6 +3,49 @@ export CCJ_PRODUCTION=1
 echo "Cook County Jail scraper started at `date`"
 source /home/ubuntu/.virtualenvs/cookcountyjail/bin/activate
 python /home/ubuntu/apps/cookcountyjail/manage.py scrape_inmates -d
+#
+# Parallel execution is limited by the number of database connections.
+# For Postgres the default number is 20, however a number of these are reserved.
+# Expermintation has found that 13 is optimal amount. Increasing the number of
+# connections allowed means the number of parallel processes can increase.
+NUMBER_PARALLEL_PROCESSES=13
+#
+# The order of parallel execution affects the over all time here is a sample of
+# the numer of records per Letter of the alphabet ordered from largest to smallest:
+# S   1020
+# M   989
+# B   952
+# W   930
+# C   845
+# H   795
+# R   660
+# J   632
+# G   582
+# P   485
+# D   454
+# L   450
+# T   449
+# A   399
+# F   298
+# K   194
+# E   187
+# N   148
+# V   148
+# O   145
+# Y   41
+# I   40
+# Z   38
+# Q   20
+# U   19
+# X   0
+#
+# Shortest execution time comes from executing the largest name groups first in order
+# of largest to smallest.
+
+# for x in S M B W C H R J G P D L T A F K E N V O Y I Z Q U X;do
+#     echo "python /home/ubuntu/apps/cookcountyjail/manage.py scrape_inmates --search" $x
+# done  | parallel -j $NUMBER_PARALLEL_PROCESSES
+# python /home/ubuntu/apps/cookcountyjail/manage.py discharge_inmates
 echo "Cook County Jail scraper finished at `date`"
 echo "Restarting nginx at `date`"
 sudo service nginx restart

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Django==1.4.2
 South==0.7.4
 argparse==1.2.1
 cssselect==0.7.1
-distribute==0.6.24
 django-tastypie==0.9.14
 eventlet==0.12.1
 greenlet==0.4.1


### PR DESCRIPTION
I have tested the robustness improvements.

You need to add GNU Parallel to the server machine. Once you have then edit cron.sh, remove the current call to scrape_inmates and uncomment the following code that runs scrapping in parallel, also uncomment the line that call discharge_inmates. Note that the script assumes that there are 20 database connections allowed on your Postgres server if the number is less than need to either increase it or reduce the number of parallel jobs in the script.

I have tested parallel scrapping from the command line went from just under 5 hours to 46 minutes.

I have not tested the cron script, nor have I tested the inner logic of the discharge_inmate script, my code inspection indicates that it is correct. The inmate selection code has been tested.

I recommend after installation of GUN Parallel program and changing the cron.sh script and checking that database connections are correctly set, that you do the following:
   1) comment out the line that calls discharge_inmates in cron.sh
   2) run cron.sh from the command line
   3) while that is running, do a code review of discharge_inmate command, fix any errors you find
   4) once cron.sh is finished running check the database, use 26thandcalifornia webapp, in particular the
       general stats options
   5) If it looks good run discharge_inmates from the command line
   6) if it runs correctly uncomment the line calling discharge_inmates and this is the new cron.sh
   7) if it did not run correctly, restore the original call to scrape_inmates and comment out the new parallel code in
      cron,sh and let me know what the errors are.
