### PR TITLE
Added new clone_db command for bootstrapping database

### DIFF
--- a/countyapi/api.py
+++ b/countyapi/api.py
@@ -195,7 +195,7 @@ class JailResource(ModelResource):
     def __init__(self, api_name=None):
         """
         Patched init that doesn't use deepcopy,
-        see https://github.com/toastdriven/django-tastypie/issues/60*60*24
+        see https://github.com/toastdriven/django-tastypie/issues/720
         """
         self.fields = {k: copy(v) for k, v in self.base_fields.iteritems()}
 

--- a/countyapi/api.py
+++ b/countyapi/api.py
@@ -195,7 +195,7 @@ class JailResource(ModelResource):
     def __init__(self, api_name=None):
         """
         Patched init that doesn't use deepcopy,
-        see https://github.com/toastdriven/django-tastypie/issues/720
+        see https://github.com/toastdriven/django-tastypie/issues/60*60*24
         """
         self.fields = {k: copy(v) for k, v in self.base_fields.iteritems()}
 
@@ -226,7 +226,7 @@ class CourtLocationResource(JailResource):
         queryset = CourtLocation.objects.all()
         limit = 100
         max_limit = 0
-        cache = SimpleCache(timeout=720)
+        cache = SimpleCache(timeout=60*60*24)
         serializer = JailSerializer()
         filtering = {
             'location': ALL,
@@ -264,7 +264,7 @@ class CourtDateResource(JailResource):
         allowed_methods = ['get']
         limit = 100
         max_limit = 0
-        cache = SimpleCache(timeout=720)
+        cache = SimpleCache(timeout=60*60*24)
         serializer = JailSerializer()
         filtering = {
             'date': ALL,
@@ -325,7 +325,7 @@ class HousingLocationResource(JailResource):
         allowed_methods = ['get']
         limit = 100
         max_limit = 0
-        cache = SimpleCache(timeout=720)
+        cache = SimpleCache(timeout=60*60*24)
         serializer = JailSerializer()
         filtering = {
             'housing_location': ALL,
@@ -354,7 +354,7 @@ class HousingHistoryResource(JailResource):
         serializer = JailSerializer()
         limit = 100
         max_limit = 0
-        cache = SimpleCache(timeout=720)
+        cache = SimpleCache(timeout=60*60*24)
         filtering = {
             'inmate': ALL_WITH_RELATIONS,
             'housing_date': ALL,
@@ -470,5 +470,5 @@ class DailyPopulationCountsResource(JailResource):
     class Meta:
         queryset = DailyPopulationCounts.objects.all()
         max_limit = 0
-        cache = SimpleCache(timeout=720)
+        cache = SimpleCache(timeout=60*60*24)
         serializer = JailSerializer()

--- a/countyapi/management/commands/clone_db.py
+++ b/countyapi/management/commands/clone_db.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
             identifiers = api_map[api][1]
 
             # query our server to get all the data of a particular API
-            result = http_get("%s%s%s" % (base_url, api, suffix), number_attempts=1, quiet=False)
+            result = http_get("%s%s%s" % (base_url, api, suffix), number_attempts=1, quiet=False, retrieval_msg="retrieving from API:")
             if result:
 
                 # parse the json we get back into a dictionary of keys and values

--- a/countyapi/management/commands/clone_db.py
+++ b/countyapi/management/commands/clone_db.py
@@ -10,6 +10,14 @@ import collections
 
 class Command(BaseCommand):
 
+    help = "Copies all data from the CookCountyJail database."
+    option_list = BaseCommand.option_list + (
+        make_option('-a', '--api', type='string', action='store', dest='api', default=False,
+                    help='APIs to clone by name, separated by comma'), 
+        make_option('-l', '--limit', type='string', action='store', dest='limit', default=False,
+                    help='take only the first n records')
+        )
+
     def handle(self, *args, **options):
 
         """
@@ -19,11 +27,12 @@ class Command(BaseCommand):
 
         base_url = "http://cookcountyjail.recoveredfactory.net/api/1.0/"
         suffix = "?format=json&limit=0"
-
+        exclude = []  
+        
         # ordereddict mapping APIs with:
         # --> a Django model that can be used to create an object; and,
         # --> a set of identifying filters needed to initialize that object
-        api_to_model_and_id = collections.OrderedDict([
+        api_map = collections.OrderedDict([
             ('countyinmate', (CountyInmate, ['jail_id'])),
             ('courtlocation', (CourtLocation, ['location'])),
             ('housinglocation', (HousingLocation, ['housing_location'])),
@@ -37,20 +46,35 @@ class Command(BaseCommand):
         #     the object we'll create with our foreign model
         # --> an API to use to get a model and initializing filters;
         #     these will be used to create the foreign object 
-        id_to_jsonkey_and_api = {
+        foreign_map = {
             'inmate' : ('inmate_jail_id', 'countyinmate'),
             'location' : ('location', 'courtlocation'),
             'housing_location' : ('location_id', 'housinglocation')
         }
 
+         # set a limit if necessary
+        if options['limit']:
+            suffix = '?format=json&limit=%s' % options['limit']
+
+
+        # build a list of excluded APIs if necessary
+        if options['api']:
+            for k in api_map.keys():
+                if k not in options['api'].split(', '):
+                    exclude.append(k)      
+
         # iterate over our APIs
-        for api in api_to_model_and_id.keys():
+        for api in api_map.keys():
+
+            # if '--api' flag was given, but this API wasn't included, ignore it.
+            if api in exclude:
+                continue
 
             # for each API, get the model we'll use to re-create all of its data            
-            model = api_to_model_and_id[api][0]
+            model = api_map[api][0]
 
             # for each API, get the identifying filters we'll need to initialize each object of this type
-            identifiers = api_to_model_and_id[api][1]
+            identifiers = api_map[api][1]
 
             # query our server to get all the data of a particular API
             result = http_get("%s%s%s" % (base_url, api, suffix), number_attempts=1, quiet=False)
@@ -63,8 +87,8 @@ class Command(BaseCommand):
                 for json_obj in json_results['objects']:
 
                     # this a dict of filters we'll use to initialize our object, when we create it.
-                    # if we have foreign keys to deal with, getting the value for each filter
-                    # is a bit more complex.
+                    # if we have foreign keys to deal with, we'll have to first get_or_create
+                    # an object based on those foreign keys.
                     filters = {}
 
                     # but if there's only one filter, the model doesn't have any foreign keys,
@@ -76,29 +100,38 @@ class Command(BaseCommand):
                         filters = {identifiers[0]: json_obj[identifiers[0]]}
                     else:
 
-                        # iterate through the filters
+                        # otherwise, iterate through the filters
                         for i in identifiers:
 
                             # if we have defined an attribute as requiring foreignkey
-                            # lookup, we get to work. Continuing from the example above,
-                            # this IS the case for the 'inmate' and 'location' identifiers
-                            if i in id_to_jsonkey_and_api.keys():
-                                json_key = id_to_jsonkey_and_api[i][0]
-                                foreign_api = id_to_jsonkey_and_api[i][1]
-                                foreign_model = api_to_model_and_id[foreign_api][0]
-                                foreign_key = api_to_model_and_id[foreign_api][1][0]
+                            # lookup, we get to work. 
+                            if i in foreign_map.keys():
+                                json_key = foreign_map[i][0]
+                                foreign_api = foreign_map[i][1]
+                                foreign_model = api_map[foreign_api][0]
+                                foreign_key = api_map[foreign_api][1][0]
+
+                                # do a foreign key lookup; this means doing get_or_create to instantiate
+                                # the object before including it as an attribute of our object;
+                                # note that we take the first match if there are multiple
                                 try:
-                                    foreigner, created = foreign_model.objects.get_or_create(**{foreign_key: json_obj[json_key]})
+                                    foreigner, created = foreign_model.objects.get_or_create(
+                                            **{foreign_key: json_obj[json_key]})
                                 except MultipleObjectsReturned:
-                                    foreigner = foreign_model.objects.filter(**{foreign_key: json_obj[json_key]})[0]
+                                    foreigner = foreign_model.objects.filter(
+                                            **{foreign_key: json_obj[json_key]})[0]
+
+                                # include the result with our list of filters
                                 filters[i] = foreigner
+
                             else:
 
-                                # but the 'date' attribute isn't defined in our map, 
-                                # so it would get pulled from the json object like normal.
+                                # if an attribute isn't defined in our map above as a foreign key, 
+                                # it would get pulled from the json object like normal. 
                                 filters[i] = json_obj[i]
 
-                    # here, we actually create our object.
+                    # here, we actually create our object, again taking the first
+                    # available, if there are multiple
                     try:
                         obj, created = model.objects.get_or_create(**filters)
                     except MultipleObjectsReturned: 
@@ -112,7 +145,8 @@ class Command(BaseCommand):
                         # if the value is None, it stays None; 
                         # if we already assigned the key in filters, don't reassign; 
                         # if key is not part of our model, don't bother assigning it (e.g. 'resource_uri', '_state')
-                       if k not in filters.keys() and v is not None and k in [a for a in obj.__dict__ if not a.startswith('_')]:
+                       if k not in filters.keys() and v is not None and \
+                                k in [a for a in obj.__dict__ if not a.startswith('_')]:
                             setattr(obj, k, v)
 
                     # finally, we're done.

--- a/countyapi/management/commands/clone_db.py
+++ b/countyapi/management/commands/clone_db.py
@@ -1,0 +1,123 @@
+from django.core.management.base import BaseCommand
+from countyapi.models import CourtDate, CourtLocation, CountyInmate, HousingHistory, HousingLocation
+from utils import http_get
+from inmate_utils import parse_court_location
+
+import json
+import collections
+import pprint
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+
+        """
+             Copies all data from each API endpoint of the server's CookCountyJail
+             database onto the caller's local machine. 
+        """
+
+        help = "Copies all data from the CookCountyJail database."
+        base_url = "http://cookcountyjail.recoveredfactory.net/api/1.0/"
+        suffix = "?format=json&limit=0"
+
+        # ordereddict mapping APIs with:
+        # --> a Django model that can be used to create an object; and,
+        # --> a set of identifying filters needed to initialize that object
+        api_to_model_and_id = collections.OrderedDict([
+            ('countyinmate', (CountyInmate, ['jail_id'])),
+            ('courtlocation', (CourtLocation, ['location'])),
+            ('housinglocation', (HousingLocation, ['housing_location'])),
+            ('courtdate', (CourtDate, ['date', 'inmate', 'location'])),
+            ('housinghistory', (HousingHistory, ['inmate', 'housing_location']))
+        ])
+        
+        # dict mapping an identifying filter with:
+        # --> a key to index into our json object with, whose
+        #     value is the value that will be used to initialize 
+        #     the object we'll create with our foreign model
+        # --> an API to use to get a model and initializing filters;
+        #     these will be used to create the foreign object 
+        id_to_jsonkey_and_api = {
+            'inmate' : ('inmate_jail_id', 'countyinmate'),
+            'location' : ('location', 'courtlocation'),
+            'housing_location' : ('location_id', 'housinglocation')
+        }
+
+        # iterate over our APIs
+        for api in api_to_model_and_id.keys():
+
+            # for each API, get the model we'll use to re-create all of its data            
+            model = api_to_model_and_id[api][0]
+
+            # for each API, get the identifying filters we'll need to initialize each object of this type
+            identifiers = api_to_model_and_id[api][1]
+
+            # query our server to get all the data of a particular API
+            result = http_get("%s%s%s" % (base_url, api, suffix), number_attempts=1, quiet=False)
+            if result:
+
+                # parse the json we get back into a dictionary of keys and values
+                json_results = json.loads(result.text)
+
+                # all our data is stored inside the 'objects' attribute
+                for json_obj in json_results['objects']:
+
+                    # this a dict of filters we'll use to initialize our object, when we create it.
+                    # if we have foreign keys to deal with, getting the value for each filter
+                    # is a bit more complex.
+                    filters = {}
+
+                    # but if there's only one filter, the model doesn't have any foreign keys,
+                    # so it's a simpler case.
+                    if len(identifiers) == 1:
+
+                        # here, we basically just mindlessly copy the value from the json object
+                        # into our dict of filters
+                        filters = {identifiers[0]: json_obj[identifiers[0]]}
+                    else:
+
+                        # In this case, we need to reference objects in other other tables just to initialize
+                        # the current object. For example, the CourtDate object requires an 'inmate' 
+                        # attribute, which is a CountyInmate object, a 'location' attribute, which is a 
+                        # CourtLocation object, and a 'date' attribute. For the first two, the json object 
+                        # only provides the identifying filters (and it might even name them differently!),
+                        # so we have to go get_or_create the objects based on the keys provided.
+
+                        # iterate through the filters
+                        for i in identifiers:
+
+                            # if we have defined an attribute as requiring foreignkey
+                            # lookup, we get to work. Continuing from the example above,
+                            # this IS the case for the 'inmate' and 'location' identifiers
+                            if i in id_to_jsonkey_and_api.keys():
+                                json_key = id_to_jsonkey_and_api[i][0]
+                                foreign_api = id_to_jsonkey_and_api[i][1]
+                                foreign_model = api_to_model_and_id[foreign_api][0]
+                                foreign_key = api_to_model_and_id[foreign_api][1][0]
+                                foreigner, created = foreign_model.objects.get_or_create(**{foreign_key: json_obj[json_key]})
+                                filters[i] = foreigner
+                            else:
+
+                                # but the 'date' attribute isn't defined in our map, 
+                                # so it would get pulled from the json object like normal.
+                                filters[i] = json_obj[i]
+
+                    # here, we actually create our object.
+                    obj, created = model.objects.get_or_create(**filters)
+
+                    # now that we've created our object, we take all the 
+                    # remaining attributes from our json object, and
+                    # reassign them to our new django object.
+                    for k, v in json_obj.iteritems():
+
+                        # if the value is None, it stays None; 
+                        # if we already assigned the key in filters, don't reassign; 
+                        # if key is not part of our model, don't bother assigning it (e.g. 'resource_uri', '_state')
+                       if k not in filters.keys() and v is not None and k in [a for a in obj.__dict__ if not a.startswith('_')]:
+                            setattr(obj, k, v)
+
+                    # finally, we're done.
+                    obj.save()
+            
+            
+        

--- a/countyapi/management/commands/utils.py
+++ b/countyapi/management/commands/utils.py
@@ -57,7 +57,7 @@ def get_next_sleep_period(current_sleep_period, attempt):
 
 def http_get(url, number_attempts=STD_NUMBER_ATTEMPTS,
              initial_sleep_period=STD_INITIAL_SLEEP_PERIOD,
-             quiet=False):
+             quiet=False, retrieval_msg="Retrieving inmate record at"):
     attempt = 1
     sleep_period = initial_sleep_period
     loud = not quiet
@@ -65,7 +65,7 @@ def http_get(url, number_attempts=STD_NUMBER_ATTEMPTS,
         sleep(sleep_period)
         try:
             if loud:
-                log.debug("%s - Retreiving inmate %s record" % (str(datetime.now()), url))
+                log.debug("%s - %s %s " % (str(datetime.now()), retrieval_msg, url))
             results = requests.get(url)
         except requests.exceptions.RequestException:
             results = None


### PR DESCRIPTION
`./manage.py clone_db` builds a Django database on your local machine from scratch using the server's API endpoints.
- Don't have to scrape for 6 hours to have a working copy of the data anymore; instead, takes about 6 minutes to get just the CountyInmate data
- Can supply `--api` and `--limit` options to have more control.

Note that for the time being, CourtDate and HousingHistory APIs seem not to work with `limit=0`, which is the default. Recommendation: run `./manage.py clone_db -a 'countyinmate, courtlocation, housinglocation'` instead (or just `-a countyinmate`). You can follow up with a limited call to CourtDate and HousingHistory APIs if you want.
