### PR TITLE
Extended environment variable runtime configuration control

### DIFF
--- a/cookcountyjail/settings.py
+++ b/cookcountyjail/settings.py
@@ -13,7 +13,23 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-if 'CCJ_PRODUCTION' in os.environ or 'USE_POSTGRES' in os.environ:
+NEGATIVE_VALUES = set(['0', 'false'])
+
+
+def use_postgres():
+    """
+    Calculates if Postgres database is to be used.
+    If environment var CCJ_PRODUCTION != False or 0 or None, then use Postgres
+    if environment var USE_POSTGRES != False or 0 or None, then use Postgres
+    """
+    ccj_production = os.environ.get('CCJ_PRODUCTION')
+    if ccj_production and ccj_production.lower() not in NEGATIVE_VALUES:
+        return True
+    use_postgres = os.environ.get('USE_POSTGRES')
+    return use_postgres and use_postgres not in NEGATIVE_VALUES
+
+
+if use_postgres():
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',

--- a/cookcountyjail/settings.py
+++ b/cookcountyjail/settings.py
@@ -3,7 +3,35 @@ import os
 SITE_STATIC_ROOT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'static')
 SITE_DIR = os.path.dirname(os.path.dirname(__file__))
 
-if not 'CCJ_PRODUCTION' in os.environ:
+NEGATIVE_VALUES = set(['0', 'false'])
+
+
+def env_var_active(env_var):
+    """
+    Calculates if an environment variable is set.
+    """
+    env_var_value = os.environ.get(env_var)
+    return env_var_value and env_var_value.lower() not in NEGATIVE_VALUES
+
+
+def in_production():
+    """
+    Calculates if to run in production mode.
+    If environment var CCJ_PRODUCTION != False or 0 or None, then in production mode
+    """
+    return env_var_active('CCJ_PRODUCTION')
+
+
+def use_postgres():
+    """
+    Calculates if Postgres database is to be used.
+    If in production mode, then use Postgres
+    if environment var USE_POSTGRES != False or 0 or None, then use Postgres
+    """
+    return in_production() or env_var_active('USE_POSTGRES')
+
+
+if not in_production():
     DEBUG = True
     TEMPLATE_DEBUG = DEBUG
 
@@ -12,21 +40,6 @@ ADMINS = (
 )
 
 MANAGERS = ADMINS
-
-NEGATIVE_VALUES = set(['0', 'false'])
-
-
-def use_postgres():
-    """
-    Calculates if Postgres database is to be used.
-    If environment var CCJ_PRODUCTION != False or 0 or None, then use Postgres
-    if environment var USE_POSTGRES != False or 0 or None, then use Postgres
-    """
-    ccj_production = os.environ.get('CCJ_PRODUCTION')
-    if ccj_production and ccj_production.lower() not in NEGATIVE_VALUES:
-        return True
-    use_postgres = os.environ.get('USE_POSTGRES')
-    return use_postgres and use_postgres not in NEGATIVE_VALUES
 
 
 if use_postgres():

--- a/countyapi/models.py
+++ b/countyapi/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+
 class CountyInmate(models.Model):
     """
     Model that represents a Cook County Jail inmate.

--- a/countyapi/urls.py
+++ b/countyapi/urls.py
@@ -2,8 +2,8 @@ from django.conf.urls import patterns, include, url
 from tastypie.api import Api
 
 from countyapi.api import CountyInmateResource, CourtLocationResource, \
-        CourtDateResource, HousingLocationResource, HousingHistoryResource, \
-        DailyPopulationCountsResource
+    CourtDateResource, HousingLocationResource, HousingHistoryResource, \
+    DailyPopulationCountsResource
 
 v1_api = Api(api_name='1.0')
 v1_api.register(CourtLocationResource())


### PR DESCRIPTION
Earlier efforts added ORM caching by using the Tastypie caching mechanism. On the production website caching has been added using Nginx caching. This removes the need for the Tastypie caching mechanism on the production system, developers or people running their own version may want to use the caching so added environment variable control.

In production, the database Postgres is used, developers may want to use this so an environment variable has been added to control selection of this.

Unless otherwise stated, environment variables are on if they exist and contain a string value other than 0 or False, matching false is a case insensitive test.

Environment variables and what they do:
- CCJ_PRODUCTION - indicates that software is running in production, which means Postgres is used as
                                   the database and debugging mode is turned off
- USE_POSTGRES - indicates that the Postgres database is to be used, if not use the default one for the
                                current mode
- USE_INTERNAL_CACHE - indicates that the ORM caching mechanism is to be used, currently Tastypie's
                                           SimpleCache
- CACHE_TTL - specifies how long, in minutes, internally cached values are to live. Default is 12 minutes.
