### PR TITLE
Added baseline unique hashes

### DIFF
--- a/countyapi/management/commands/inmate_details.py
+++ b/countyapi/management/commands/inmate_details.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pyquery import PyQuery as pq
 from utils import http_get
+import hashlib
 
 NUMBER_OF_ATTEMPTS = 5
 
@@ -23,6 +24,19 @@ class InmateDetails:
         if self.__inmate_found:
             inmate_doc = pq(inmate_result.content)
             self.__columns = inmate_doc('table tr:nth-child(2n) td')
+
+    def hash_id(self):
+        id_string = "%s%s%s%s" % (
+            self.name().replace(" ", ""),
+            self.birth_date().strftime('%m%d%Y'), 
+            self.race()[0],
+            self.gender(),
+        )
+        byte_string = id_string.encode('utf-8')
+        return hashlib.sha256(byte_string).hexdigest()
+
+    def name(self):
+        return self.column_content(1)
 
     def age_at_booking(self):
         """

--- a/countyapi/management/commands/inmate_utils.py
+++ b/countyapi/management/commands/inmate_utils.py
@@ -39,6 +39,7 @@ def create_update_inmate(inmate_details, inmate=None):
     else:
         created = False
     clear_discharged(inmate)
+    store_hash_id(inmate, inmate_details)
     store_booking_date(inmate, inmate_details)
     store_physical_characteristics(inmate, inmate_details)
     store_housing_location(inmate, inmate_details)
@@ -223,6 +224,9 @@ def set_sub_division(location_object, sub_division, sub_division_location):
     location_object.sub_division = sub_division
     location_object.sub_division_location = join_with_space_and_convert_spaces(sub_division_location)
 
+
+def store_hash_id(inmate, inmate_details):
+    inmate.person_id = inmate_details.hash_id()
 
 def store_bail_info(inmate, inmate_details):
     # Bond: If the value is an integer, it's a dollar

--- a/countyapi/migrations/0014_auto__add_field_countyinmate_person_id.py
+++ b/countyapi/migrations/0014_auto__add_field_countyinmate_person_id.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'CountyInmate.person_id'
+        db.add_column('countyapi_countyinmate', 'person_id',
+                      self.gf('django.db.models.fields.CharField')(max_length=32, null=True),
+                      keep_default=False)
+
+    def backwards(self, orm):
+        # Deleting field 'CountyInmate.person_id'
+        db.delete_column('countyapi_countyinmate', 'person_id')
+
+    models = {
+        'countyapi.chargeshistory': {
+            'Meta': {'object_name': 'ChargesHistory'},
+            'charges': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'charges_citation': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'date_seen': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inmate': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'charges_history'", 'to': "orm['countyapi.CountyInmate']"})
+        },
+        'countyapi.countyinmate': {
+            'Meta': {'ordering': "['-jail_id']", 'object_name': 'CountyInmate'},
+            'age_at_booking': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'bail_amount': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'bail_status': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'}),
+            'booking_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'discharge_date_earliest': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'discharge_date_latest': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'gender': ('django.db.models.fields.CharField', [], {'max_length': '1', 'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'jail_id': ('django.db.models.fields.CharField', [], {'max_length': '15', 'primary_key': 'True'}),
+            'last_seen_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'person_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True'}),
+            'race': ('django.db.models.fields.CharField', [], {'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'weight': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'countyapi.courtdate': {
+            'Meta': {'ordering': "['date']", 'object_name': 'CourtDate'},
+            'date': ('django.db.models.fields.DateField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inmate': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'court_dates'", 'to': "orm['countyapi.CountyInmate']"}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'court_dates'", 'to': "orm['countyapi.CourtLocation']"})
+        },
+        'countyapi.courtlocation': {
+            'Meta': {'object_name': 'CourtLocation'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'}),
+            'branch_name': ('django.db.models.fields.CharField', [], {'max_length': '60', 'null': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.TextField', [], {}),
+            'location_name': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True'}),
+            'room_number': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '3', 'null': 'True'}),
+            'zip_code': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'countyapi.dailypopulationcounts': {
+            'Meta': {'ordering': "['date']", 'object_name': 'DailyPopulationCounts'},
+            'date': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'female_as': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'female_b': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'female_bk': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'female_in': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'female_lb': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'female_lt': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'female_lw': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'female_w': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'female_wh': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'male_as': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'male_b': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'male_bk': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'male_in': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'male_lb': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'male_lt': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'male_lw': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'male_w': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'male_wh': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'total': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'countyapi.housinghistory': {
+            'Meta': {'object_name': 'HousingHistory'},
+            'housing_date_discovered': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'housing_location': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'housing_history'", 'to': "orm['countyapi.HousingLocation']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inmate': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'housing_history'", 'to': "orm['countyapi.CountyInmate']"})
+        },
+        'countyapi.housinglocation': {
+            'Meta': {'object_name': 'HousingLocation'},
+            'division': ('django.db.models.fields.CharField', [], {'max_length': '4'}),
+            'housing_location': ('django.db.models.fields.CharField', [], {'max_length': '40', 'primary_key': 'True'}),
+            'in_jail': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'in_program': ('django.db.models.fields.CharField', [], {'max_length': '60'}),
+            'sub_division': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'sub_division_location': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'countyapi.inmatesummaries': {
+            'Meta': {'object_name': 'InmateSummaries'},
+            'current_inmate_count': ('django.db.models.fields.IntegerField', [], {}),
+            'date': ('django.db.models.fields.DateField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        }
+    }
+
+    complete_apps = ['countyapi']

--- a/countyapi/models.py
+++ b/countyapi/models.py
@@ -6,6 +6,7 @@ class CountyInmate(models.Model):
     Model that represents a Cook County Jail inmate.
     """
     jail_id = models.CharField(max_length=15, primary_key=True)
+    person_id = models.CharField(max_length=32, null=True) 
     url = models.CharField(max_length=255)
     race = models.CharField(max_length=4, null=True, blank=True)
     last_seen_date = models.DateTimeField(auto_now=True)


### PR DESCRIPTION
### What this change doesn't do

This change does NOT re-work our models at all, except to add a new field associated with an inmate, called `person_id`. It's a bit scaled back from the [earlier pull](https://github.com/sc3/cookcountyjail/pull/117).
### What it does do
- In addition to the new `person_id` field on our model, the data to fill this field is now created at scrape-time, with a SHA-256 hashing function, from four data: 
  - name
  - birthdate
  - (first letter of) race
  - gender
- The south migration for the new schema is also done.
- This should at least allow us a certain amount of backwards compatibility between API 1.0 and whatever comes after. If we ever want to try to port the data we scrape after this pull, we will have the hashed `person_id` (which we otherwise can't recreate after the person leaves the Cook County Sheriff's website).
