### PR TITLE
Fixed relative imports by making them explicit; removed sys.path alterations

### DIFF
--- a/ccj/__init__.py
+++ b/ccj/__init__.py
@@ -1,5 +1,5 @@
-from app import app, db
-from models import *
-import config
+from .app import app, db
+from .models import *
+from . import config
 
 app.config.from_object(config)

--- a/ccj/models/__init__.py
+++ b/ccj/models/__init__.py
@@ -1,1 +1,1 @@
-from person import Person
+from .person import Person

--- a/manage.py
+++ b/manage.py
@@ -1,9 +1,7 @@
 import argparse, sys
-sys.path.append("ccj")
-sys.path.append("scripts")
 
-from app import *
-from database import *
+from ccj import app, db
+from scripts import setup_db
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,1 @@
-from database import *
+from .database import *


### PR DESCRIPTION
So the reason we were getting trouble with the relative imports, where we import from the current directory, is because the syntax for relative imports changed with Python 3. They're still available, but they're differentiated from absolute imports with the 'dot' syntax for referencing the current directory, e.g.:

```
from .app import app, db
```

After banging my head against a wall for quite awhile with this, I realized I just didn't know something about Python 3. We have to be more careful to actually use Python 3 if we're committed to doing so.

I went through and changed all our relative imports to this new syntax. I also cleaned up the imports in manage.py, so we're only importing what we use.
