### PR TITLE
Added confirmation check of recently discharged inmates.

### DIFF
--- a/countyapi/management/scraper/inmate.py
+++ b/countyapi/management/scraper/inmate.py
@@ -1,5 +1,6 @@
 
-from datetime import datetime, date
+from datetime import datetime, date, timedelta, time
+
 from django.db.utils import DatabaseError
 
 from countyapi.management.commands.utils import convert_to_int
@@ -9,6 +10,10 @@ from countyapi.models import CountyInmate
 from charges import Charges
 from court_date_info import CourtDateInfo
 from housing_location_info import HousingLocationInfo
+
+_MIDNIGHT = time()
+_ONE_DAY = timedelta(1)
+_NUMBER_DAYS_AGO = 5
 
 
 class Inmate:
@@ -67,6 +72,13 @@ class Inmate:
         @rtype : list of inmates booked on specified day
         """
         return CountyInmate.objects.filter(booking_date=booking_date)
+
+    @staticmethod
+    def recently_discharged_inmates():
+        today = date.today()
+        discharge_starting_date = datetime.combine(today - _ONE_DAY * _NUMBER_DAYS_AGO, _MIDNIGHT)
+        return CountyInmate.objects.filter(discharge_date_earliest__gte=discharge_starting_date,
+                                           last_seen_date__lt=today)
 
     def save(self):
         """

--- a/countyapi/management/scraper/inmates_scraper.py
+++ b/countyapi/management/scraper/inmates_scraper.py
@@ -56,6 +56,17 @@ class InmatesScraper:
         self._write_commands_q.put((method, args))
         gevent.sleep(0)
 
+    def resurrect_if_found(self, inmate_id):
+        self._put(self._resurrect_if_found, inmate_id)
+
+    def resurrect_if_found(self, inmate_id):
+        if self._verbose:
+            self._debug('check if really discharged inmate %s' % inmate_id)
+        worked, inmate_details_in_html = self._http.get(CCJ_INMATE_DETAILS_URL + inmate_id)
+        if worked:
+            self._debug('Resurrected inmate %s' % inmate_id)
+            self._inmates.update(self._inmate_details_class(inmate_details_in_html))
+
     def _setup_command_system(self):
         return JoinableQueue(None), [gevent.spawn(self._process_commands) for x in range(self._workers_to_start)]
 

--- a/countyapi/management/scraper/search_commands.py
+++ b/countyapi/management/scraper/search_commands.py
@@ -13,6 +13,7 @@ ONE_DAY = timedelta(1)
 class SearchCommands:
 
     _NOTIFICATION_MSG_TEMPLATE = 'SearchCommands: finished generating %s'
+    FINISHED_CHECK_DISCHARGED_INMATES = _NOTIFICATION_MSG_TEMPLATE % 'check for if inmate really is discharged'
     FINISHED_FIND_INMATES = _NOTIFICATION_MSG_TEMPLATE % 'find inmates commands'
     FINISHED_UPDATE_INMATES_STATUS = _NOTIFICATION_MSG_TEMPLATE % 'update inmates status'
 
@@ -20,6 +21,14 @@ class SearchCommands:
         self._inmate_scraper = inmate_scraper
         self._monitor = monitor
         self._commands = self._setup_command_system()
+
+    def check_if_really_discharged(self, discharged_inmates_ids):
+        self._put(self._check_if_really_discharged, discharged_inmates_ids)
+
+    def _check_if_really_discharged(self, discharged_inmates_ids):
+        for discharged_inmate_id in discharged_inmates_ids:
+            self._inmate_scraper.resurrect_if_found(discharged_inmate_id)
+        self._monitor.notify(self.__class__, self.FINISHED_CHECK_DISCHARGED_INMATES)
 
     def _debug(self, msg):
         self._monitor.debug('SearchCommands: %s' % msg)

--- a/countyapi/management/scraper/search_commands.py
+++ b/countyapi/management/scraper/search_commands.py
@@ -13,8 +13,9 @@ ONE_DAY = timedelta(1)
 class SearchCommands:
 
     _NOTIFICATION_MSG_TEMPLATE = 'SearchCommands: finished generating %s'
-    FINISHED_CHECK_DISCHARGED_INMATES = _NOTIFICATION_MSG_TEMPLATE % 'check for if inmate really is discharged'
     FINISHED_FIND_INMATES = _NOTIFICATION_MSG_TEMPLATE % 'find inmates commands'
+    FINISHED_CHECK_OF_RECENTLY_DISCHARGED_INMATES = \
+        _NOTIFICATION_MSG_TEMPLATE % 'finished generate check of recently discharged inmates commands'
     FINISHED_UPDATE_INMATES_STATUS = _NOTIFICATION_MSG_TEMPLATE % 'update inmates status'
 
     def __init__(self, inmate_scraper, monitor):
@@ -28,7 +29,7 @@ class SearchCommands:
     def _check_if_really_discharged(self, discharged_inmates_ids):
         for discharged_inmate_id in discharged_inmates_ids:
             self._inmate_scraper.resurrect_if_found(discharged_inmate_id)
-        self._monitor.notify(self.__class__, self.FINISHED_CHECK_DISCHARGED_INMATES)
+        self._monitor.notify(self.__class__, self.FINISHED_CHECK_OF_RECENTLY_DISCHARGED_INMATES)
 
     def _debug(self, msg):
         self._monitor.debug('SearchCommands: %s' % msg)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -6,7 +6,7 @@ from datetime import date, timedelta
 from countyapi.management.scraper.controller import Controller
 from countyapi.management.scraper.monitor import Monitor
 from countyapi.management.scraper.heartbeat import HEARTBEAT_INTERVAL
-from countyapi.management.scraper.search_commands import SearchCommands, MAX_INMATE_NUMBER
+from countyapi.management.scraper.search_commands import SearchCommands
 from countyapi.management.scraper.inmates_scraper import InmatesScraper
 from countyapi.management.scraper.inmates import Inmates
 
@@ -25,42 +25,57 @@ class TestController:
 
     def send_notification(self, obj_instance, msg):
         self._monitor.notify(obj_instance.__class__, msg)
-        gevent.sleep(0)
+        gevent.sleep(TIME_PADDING)
 
     def stop_controller(self, controller):
         self._monitor.notify(self.__class__, controller.stop_command())
         gevent.sleep(TIME_PADDING)
         assert not controller.is_running
 
-    # def test_controller_can_be_stopped(self):
-    #     inmates = Mock()
-    #     controller = Controller(self._monitor, self._search, self._inmate_scraper, inmates)
-    #     assert not controller.is_running
-    #     assert controller.heartbeat_count == 0
-    #     run_controller(controller)
-    #     assert controller.is_running
-    #     expected_num_heartbeats = 2
-    #     gevent.sleep(HEARTBEAT_INTERVAL * expected_num_heartbeats + TIME_PADDING)
-    #     self.stop_controller(controller)
-    #     assert controller.heartbeat_count == expected_num_heartbeats
-    #
-    # def test_updates_and_searches_new_inmates(self):
-    #     inmates = Mock()
-    #     controller = Controller(self._monitor, self._search, self._inmate_scraper, inmates)
-    #     run_controller(controller)
-    #     assert inmates.active_inmates_ids.call_args_list == [call(controller.inmates_response_q)]
-    #     active_jail_ids = [2, 78]
-    #     controller.inmates_response_q.put(active_jail_ids)
-    #     gevent.sleep(TIME_PADDING)
-    #     assert self._search.update_inmates_status.call_args_list == [call(active_jail_ids)]
-    #     self.send_notification(self._search, SearchCommands.FINISHED_UPDATE_INMATES_STATUS)
-    #     assert self._search.find_inmates.call_args_list == [call()]
-    #     self.send_notification(self._search, SearchCommands.FINISHED_FIND_INMATES)
-    #     assert self._inmate_scraper.finish.call_args_list == [call()]
-    #     self.send_notification(self._inmate_scraper, InmatesScraper.FINISHED_PROCESSING)
-    #     assert inmates.finish.call_args_list == [call()]
-    #     self.send_notification(inmates, Inmates.FINISHED_PROCESSING)
-    #     assert not controller.is_running
+    def test_controller_can_be_stopped(self):
+        inmates = Mock()
+        controller = Controller(self._monitor, self._search, self._inmate_scraper, inmates)
+        assert not controller.is_running
+        assert controller.heartbeat_count == 0
+        run_controller(controller)
+        assert controller.is_running
+        expected_num_heartbeats = 2
+        gevent.sleep(HEARTBEAT_INTERVAL * expected_num_heartbeats + TIME_PADDING)
+        self.stop_controller(controller)
+        assert controller.heartbeat_count == expected_num_heartbeats
+
+    def test_scraping(self):
+        """
+        This tests the normal operating loop of the scraper. It makes sure that it orchestrates
+        the sequence correctly and that no operation is missing. Basically the scraper needs
+        to do the following:
+            - initiate check of active inmates
+            - search for new inmates over the last 5 days or so
+            - initiate check if inmates have really been discharged from the last few days
+            - once search command generation is finished, tell inmate_scraper to signal when finished
+            - once inmate_scraper is finished, tell inmates to signal when it finishes
+            - once inmates is finished halt processing
+        This test makes sure that the above happens in that order
+        """
+        inmates = Mock()
+        controller = Controller(self._monitor, self._search, self._inmate_scraper, inmates)
+        run_controller(controller)
+        assert inmates.active_inmates_ids.call_args_list == [call(controller.inmates_response_q)]
+        active_jail_ids = [2, 78]
+        send_response(controller, active_jail_ids)
+        assert self._search.update_inmates_status.call_args_list == [call(active_jail_ids)]
+        self.send_notification(self._search, SearchCommands.FINISHED_UPDATE_INMATES_STATUS)
+        assert self._search.find_inmates.call_args_list == [call()]
+        self.send_notification(self._search, SearchCommands.FINISHED_FIND_INMATES)
+        assert inmates.recently_discharged_inmates_ids.call_args_list == [call(controller.inmates_response_q)]
+        send_response(controller, active_jail_ids)
+        assert self._search.check_if_really_discharged.call_args_list == [call(active_jail_ids)]
+        self.send_notification(self._search, SearchCommands.FINISHED_CHECK_OF_RECENTLY_DISCHARGED_INMATES)
+        assert self._inmate_scraper.finish.call_args_list == [call()]
+        self.send_notification(self._inmate_scraper, InmatesScraper.FINISHED_PROCESSING)
+        assert inmates.finish.call_args_list == [call()]
+        self.send_notification(inmates, Inmates.FINISHED_PROCESSING)
+        assert not controller.is_running
 
     def test_search_missing_inmates(self):
         inmates = Mock()
@@ -70,8 +85,7 @@ class TestController:
         assert inmates.known_inmates_ids_starting_with.call_args_list == [call(controller.inmates_response_q,
                                                                                start_date)]
         known_inmate_ids = []
-        controller.inmates_response_q.put(known_inmate_ids)
-        gevent.sleep(TIME_PADDING)
+        send_response(controller, known_inmate_ids)
         assert self._search.find_inmates.call_args_list == [call([], start_date=start_date)]
         self.send_notification(self._search, SearchCommands.FINISHED_FIND_INMATES)
         assert self._inmate_scraper.finish.call_args_list == [call()]
@@ -79,6 +93,16 @@ class TestController:
         assert inmates.finish.call_args_list == [call()]
         self.send_notification(inmates, Inmates.FINISHED_PROCESSING)
         assert not controller.is_running
+
+
+def controller_missing_inmates(controller, start_date):
+    """
+    Runs the controller in a greenlet as this is a blocking call
+    @type controller: Controller
+    @return: void
+    """
+    controller.find_missing_inmates(start_date)
+    gevent.sleep(0.001)
 
 
 def run_controller(controller):
@@ -91,11 +115,6 @@ def run_controller(controller):
     gevent.sleep(0.001)
 
 
-def controller_missing_inmates(controller, start_date):
-    """
-    Runs the controller in a greenlet as this is a blocking call
-    @type controller: Controller
-    @return: void
-    """
-    controller.find_missing_inmates(start_date)
-    gevent.sleep(0.001)
+def send_response(controller, response_msg):
+    controller.inmates_response_q.put(response_msg)
+    gevent.sleep(TIME_PADDING)

--- a/tests/test_inmate_scraper.py
+++ b/tests/test_inmate_scraper.py
@@ -90,6 +90,20 @@ class Test_InmatesScraper:
         inmate_scraper.finish()
         assert monitor.notify.call_args_list == [call(inmate_scraper.__class__, inmate_scraper.FINISHED_PROCESSING)]
 
+    def test_resurrect_if_found(self):
+        http = Http_TestDouble()
+        inmates = Mock()
+        monitor = Mock()
+        inmate_scraper = InmatesScraper(http, inmates, InmateDetails_TestDouble, monitor)
+        jail_ids = ['jail_id_%d' % id for id in range(1, 5)]
+        expected_update_calls_args = []
+        for jail_id in jail_ids:
+            if not http.bad_response_desired(jail_id):
+                expected_update_calls_args.append(call(InmateDetails_TestDouble(jail_id)))
+        for jail_id in jail_ids:
+            inmate_scraper.resurrect_if_found(jail_id)
+        assert inmates.update.call_args_list == expected_update_calls_args
+
 
 class InmateDetails_TestDouble:
 

--- a/tests/test_search_commands.py
+++ b/tests/test_search_commands.py
@@ -67,7 +67,7 @@ class Test_SearchCommands:
         search_commands.check_if_really_discharged(gen_inmate_ids(yesterday(), number_to_fetch))
         assert inmate_scraper.resurrect_if_found.call_args_list == expected
         assert monitor.notify.call_args_list == [call(search_commands.__class__,
-                                                      search_commands.FINISHED_CHECK_DISCHARGED_INMATES)]
+                                                      search_commands.FINISHED_CHECK_OF_RECENTLY_DISCHARGED_INMATES)]
 
 
 def expect_jail_id_calls(number_to_fetch):

--- a/tests/test_search_commands.py
+++ b/tests/test_search_commands.py
@@ -58,6 +58,17 @@ class Test_SearchCommands:
         assert inmate_scraper.create_if_exists.call_args_list == expected
         assert monitor.notify.call_args_list == [call(search_commands.__class__, search_commands.FINISHED_FIND_INMATES)]
 
+    def test_check_if_really_discharged(self):
+        number_to_fetch = 3
+        expected = expect_jail_id_calls(number_to_fetch)
+        inmate_scraper = Mock()
+        monitor = Mock()
+        search_commands = SearchCommands(inmate_scraper, monitor)
+        search_commands.check_if_really_discharged(gen_inmate_ids(yesterday(), number_to_fetch))
+        assert inmate_scraper.resurrect_if_found.call_args_list == expected
+        assert monitor.notify.call_args_list == [call(search_commands.__class__,
+                                                      search_commands.FINISHED_CHECK_DISCHARGED_INMATES)]
+
 
 def expect_jail_id_calls(number_to_fetch):
     expected = []


### PR DESCRIPTION
Issue #262 identified that sometimes the scraper declares an inmate as discharged, due to a number of factors, when in fact the inmate has not been discharged. By checking the inmates discharged from the last 5 days the expectation is that it will catch these cases.
