### PR TITLE
Issue #355 - fixed error in migration when changing field booking_date t...

### DIFF
--- a/countyapi/migrations/0032_auto__chg_field_countyinmate_booking_date.py
+++ b/countyapi/migrations/0032_auto__chg_field_countyinmate_booking_date.py
@@ -8,11 +8,14 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
+
         # Changing field 'CountyInmate.booking_date'
-        db.alter_column(u'countyapi_countyinmate', 'booking_date', self.gf('django.db.models.fields.DateField'))
+        db.alter_column(u'countyapi_countyinmate', 'booking_date', self.gf('django.db.models.fields.DateField')(default=datetime.datetime(2014, 5, 5, 0, 0)))
 
     def backwards(self, orm):
-        raise RuntimeError("Cannot reverse this migration.")
+
+        # Changing field 'CountyInmate.booking_date'
+        db.alter_column(u'countyapi_countyinmate', 'booking_date', self.gf('django.db.models.fields.DateField')(null=True))
 
     models = {
         u'countyapi.chargeshistory': {

--- a/countyapi/migrations/0033_auto__chg_field_countyinmate_last_seen_date.py
+++ b/countyapi/migrations/0033_auto__chg_field_countyinmate_last_seen_date.py
@@ -8,17 +8,14 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        """
-        End of converting CountyInmate.booking_date field from datetime to date
-        turning back on auto updating of last_seen_date field.
-        @param orm:
-        @return:
-        """
+
         # Changing field 'CountyInmate.last_seen_date'
         db.alter_column(u'countyapi_countyinmate', 'last_seen_date', self.gf('django.db.models.fields.DateTimeField')(auto_now=True))
 
     def backwards(self, orm):
-        raise RuntimeError("Cannot reverse this migration.")
+
+        # Changing field 'CountyInmate.last_seen_date'
+        db.alter_column(u'countyapi_countyinmate', 'last_seen_date', self.gf('django.db.models.fields.DateTimeField')())
 
     models = {
         u'countyapi.chargeshistory': {


### PR DESCRIPTION
...o disallow nulls. It must have a default value which was missing in faulty version.
